### PR TITLE
Field types added

### DIFF
--- a/src/components/DynamicForm.jsx
+++ b/src/components/DynamicForm.jsx
@@ -1,53 +1,89 @@
 import React from 'react';
 import { useFormik } from 'formik';
-import * as yup from 'yup';
-import { TextField, Button, Select, MenuItem, FormControl, InputLabel } from '@mui/material';
+import { TextField, Checkbox, FormControlLabel, Select, MenuItem, Button, TextareaAutosize } from '@mui/material';
 
-export const DynamicForm = ({ config }) => {
-    const validationSchema = yup.object().shape(config.validationSchema);
+const DynamicForm = ({ config }) => {
+    const { initialValues, validationSchema, fields } = config;
     const formik = useFormik({
-        initialValues: config.initialValues,
-        validationSchema: validationSchema,
+        initialValues,
+        validationSchema,
         onSubmit: (values) => {
-            alert(JSON.stringify(values, null, 2));
+            console.log(values);
         },
     });
 
-    return (
-        <form onSubmit={formik.handleSubmit}>
-            {config.fields.map((field) => (
-                <div key={field.name} style={{ marginBottom: '16px' }}>
-                    {field.type === 'text' && (
-                        <TextField
-                            fullWidth
-                            id={field.name}
-                            name={field.name}
-                            label={field.label}
-                            value={formik.values[field.name]}
-                            onChange={formik.handleChange}
-                            error={formik.touched[field.name] && Boolean(formik.errors[field.name])}
-                            helperText={formik.touched[field.name] && formik.errors[field.name]}
-                        />
-                    )}
-                    {field.type === 'select' && (
-                        <FormControl fullWidth>
-                            <InputLabel id={`${field.name}-label`}>{field.label}</InputLabel>
-                            <Select
-                                labelId={`${field.name}-label`}
+    const renderField = (field) => {
+        switch (field.type) {
+            case 'text':
+                return (
+                    <TextField
+                        key={field.name}
+                        id={field.name}
+                        name={field.name}
+                        label={field.label}
+                        value={formik.values[field.name]}
+                        onChange={formik.handleChange}
+                        error={formik.touched[field.name] && Boolean(formik.errors[field.name])}
+                        helperText={formik.touched[field.name] && formik.errors[field.name]}
+                    />
+                );
+            case 'select':
+                return (
+                    <TextField
+                        key={field.name}
+                        select
+                        id={field.name}
+                        name={field.name}
+                        label={field.label}
+                        value={formik.values[field.name]}
+                        onChange={formik.handleChange}
+                        error={formik.touched[field.name] && Boolean(formik.errors[field.name])}
+                        helperText={formik.touched[field.name] && formik.errors[field.name]}
+                    >
+                        {field.options.map((option) => (
+                            <MenuItem key={option.value} value={option.value}>
+                                {option.label}
+                            </MenuItem>
+                        ))}
+                    </TextField>
+                );
+            case 'checkbox':
+                return (
+                    <FormControlLabel
+                        key={field.name}
+                        control={
+                            <Checkbox
                                 id={field.name}
                                 name={field.name}
-                                value={formik.values[field.name]}
+                                checked={formik.values[field.name]}
                                 onChange={formik.handleChange}
-                                error={formik.touched[field.name] && Boolean(formik.errors[field.name])}
-                            >
-                                {field.options.map((option) => (
-                                    <MenuItem key={option.value} value={option.value}>
-                                        {option.label}
-                                    </MenuItem>
-                                ))}
-                            </Select>
-                        </FormControl>
-                    )}
+                            />
+                        }
+                        label={field.label}
+                    />
+                );
+            case 'textarea':
+                return (
+                    <TextareaAutosize
+                        key={field.name}
+                        id={field.name}
+                        name={field.name}
+                        label={field.label}
+                        value={formik.values[field.name]}
+                        onChange={formik.handleChange}
+                        style={{ width: '100%', minHeight: '100px' }}
+                    />
+                );
+            default:
+                return null;
+        }
+    };
+
+    return (
+        <form onSubmit={formik.handleSubmit}>
+            {fields.map((field) => (
+                <div key={field.name} style={{ marginBottom: '16px' }}>
+                    {renderField(field)}
                 </div>
             ))}
             <Button color="primary" variant="contained" type="submit">

--- a/src/formConfig.js
+++ b/src/formConfig.js
@@ -5,12 +5,16 @@ export const formConfig = {
         name: '',
         age: '',
         gender: '',
+        agreeToTerms: false,
+        comments: '',
     },
-    validationSchema: {
+    validationSchema: yup.object({
         name: yup.string().required('Name is required'),
         age: yup.number().required('Age is required').min(0, 'Age must be greater than zero'),
         gender: yup.string().required('Gender is required'),
-    },
+        agreeToTerms: yup.bool().oneOf([true], 'You must agree to the terms'),
+        comments: yup.string().required('Comments are required'),
+    }),
     fields: [
         { name: 'name', type: 'text', label: 'Name' },
         { name: 'age', type: 'text', label: 'Age' },
@@ -24,5 +28,7 @@ export const formConfig = {
                 { value: 'other', label: 'Other' },
             ],
         },
+        { name: 'agreeToTerms', type: 'checkbox', label: 'Agree to Terms' },
+        { name: 'comments', type: 'textarea', label: 'Comments' },
     ],
 };


### PR DESCRIPTION
With the modifications made, the following field types have been added to the vite-easy-form:

Checkbox: A field that allows the user to select or deselect an option.
Textarea: A multi-line text field that allows the user to enter longer text.

In addition to the existing ones:

Text: A single-line text field.
Select: A dropdown menu that allows the user to select an option from a list.


Here is a summary of the currently supported field types:

text: Single-line text field.
select: Dropdown menu.
checkbox: Field that allows selecting or deselecting an option.
textarea: Multi-line text field.